### PR TITLE
[fix] Issue 10: プレビューと選択がずれる問題を修正

### DIFF
--- a/lua/mini-pick-preview/events.lua
+++ b/lua/mini-pick-preview/events.lua
@@ -24,6 +24,10 @@ local function update_preview(item)
 	if preview_buf and vim.api.nvim_buf_is_valid(preview_buf) then
 		pcall(function()
 			MiniPick.default_preview(preview_buf, item)
+			-- 非同期処理を待ってから画面更新
+			vim.defer_fn(function()
+				pcall(vim.cmd, "redraw")
+			end, MiniPick.config.delay.async)
 		end)
 	end
 end


### PR DESCRIPTION
mini.nvim のコミット `7ff1d30` で定期的な redraw が廃止され、
非同期処理を待ってから画面更新するようになった。

本プラグインでも default_preview() 呼び出し後に
delay.async ミリ秒後に redraw を投げることで、
非同期処理の完了を待ってからプレビュー表示を更新する
