### PR TITLE
docs: Issue 6 ウィンドウサイズの動的調整方法をドキュメントに追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,5 +52,25 @@ require("mini.pick").setup({
 })
 ```
 
-If the preview window is hidden behind the search window, please explicitly specify `col`, `width`, and `anchor` in mini.pick's setup:
+If the preview window is hidden behind the search window, please explicitly specify `col`, `width`, and `anchor` in mini.pick's setup.
+
+### Dynamic window size adjustment
+
+When using a fixed `width` configuration, the picker window always uses the same width regardless of the terminal size. This can cause layout issues if the terminal is resized.
+
+To adjust the picker window size dynamically each time the picker is opened, pass a **function** instead of a static value for the `config` option. The function is evaluated every time the picker starts, allowing it to adapt to the current terminal width:
+
+```lua
+require("mini.pick").setup({
+  window = {
+    config = function()
+      return {
+        width = math.floor((vim.o.columns - 8) / 2),
+      }
+    end,
+  },
+})
+```
+
+This approach ensures the picker always uses an appropriate width based on the current terminal size, preventing the preview window from overlapping.
 

--- a/doc/mini-pick-preview.txt
+++ b/doc/mini-pick-preview.txt
@@ -77,6 +77,32 @@ but it is actually drawn at position `52`. `52` is the sum of `width + border`.
 If the preview window is hidden behind the search window, please explicitly
 specify `col`, `width`, and `anchor` in mini.pick's setup.
 
+Dynamic window size adjustment
+~
+
+When using a fixed `width` configuration, the picker window always uses the
+same width regardless of the terminal size. This can cause layout issues if
+the terminal is resized.
+
+To adjust the picker window size dynamically each time the picker is opened,
+pass a function instead of a static value for the `config` option. The
+function is evaluated every time the picker starts, allowing it to adapt to
+the current terminal width:
+>lua
+  require("mini.pick").setup({
+    window = {
+      config = function()
+        return {
+          width = math.floor((vim.o.columns - 8) / 2),
+        }
+      end,
+    },
+  })
+<
+
+This approach ensures the picker always uses an appropriate width based on
+the current terminal size, preventing the preview window from overlapping.
+
 ------------------------------------------------------------------------------
                                                    *mini-pick-preview-api-setup*
                                   `M.setup`()

--- a/lua/mini-pick-preview/init.lua
+++ b/lua/mini-pick-preview/init.lua
@@ -71,6 +71,32 @@
 ---
 --- If the preview window is hidden behind the search window, please explicitly
 --- specify `col`, `width`, and `anchor` in mini.pick's setup.
+---
+--- Dynamic window size adjustment
+--- ~
+---
+--- When using a fixed `width` configuration, the picker window always uses the
+--- same width regardless of the terminal size. This can cause layout issues if
+--- the terminal is resized.
+---
+--- To adjust the picker window size dynamically each time the picker is opened,
+--- pass a function instead of a static value for the `config` option. The
+--- function is evaluated every time the picker starts, allowing it to adapt to
+--- the current terminal width:
+--- >lua
+---   require("mini.pick").setup({
+---     window = {
+---       config = function()
+---         return {
+---           width = math.floor((vim.o.columns - 8) / 2),
+---         }
+---       end,
+---     },
+---   })
+--- <
+---
+--- This approach ensures the picker always uses an appropriate width based on
+--- the current terminal size, preventing the preview window from overlapping.
 ---@tag mini-pick-preview-troubleshooting
 ---@toc_entry Troubleshooting
 


### PR DESCRIPTION
## Summary

Issue #6 に対応して、`mini.pick` の `config` に関数を指定することでウィンドウサイズを動的に調整する方法をドキュメントに追加しました。

## Changes

- lua/mini-pick-preview/init.lua: Troubleshooting セクションに「Dynamic window size adjustment」を追加
- doc/mini-pick-preview.txt: 生成されたドキュメントを更新
- README.md: 動的ウィンドウサイズ調整についてのセクションを追加

## Details

`config` を関数にすることで、ピッカーを開くたびにウィンドウサイズが評価され、ターミナルサイズの変更に対応できます。なぜ関数にする必要があるのかを明確に説明しています。

Closes #6